### PR TITLE
解决textViewDidChange不调用，同时updateSyntax也没调用，导致输入新内容后右滑预览没有更新的bug;

### DIFF
--- a/MarkLite/MarkLite/View/EditView.m
+++ b/MarkLite/MarkLite/View/EditView.m
@@ -33,10 +33,19 @@
     [self addSubview:placeholderLable];
 
     self.delegate = self;
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(textChanged:)
+                                                 name:UITextViewTextDidChangeNotification
+                                               object:self];
     return self;
 }
 
 - (void)textViewDidChange:(UITextView *)textView
+{
+    [self updateSyntax];
+}
+
+- (void)textChanged:(NSNotification *)notification
 {
     [self updateSyntax];
 }
@@ -82,6 +91,9 @@
 - (void)dealloc
 {
     NSLog(@"%@ dealloc",NSStringFromClass(self.class));
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:UITextViewTextDidChangeNotification
+                                                  object:self];
 }
 
 @end


### PR DESCRIPTION
Tells the delegate that the text or attributes in the specified text view were changed by the user.